### PR TITLE
Update Guzzle and fix SupplierInvoice

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "guzzlehttp/guzzle": "6.2.3",
+    "guzzlehttp/guzzle": "^6.2.3",
     "sabre/xml": "^1.2"
   },
   "require-dev": {

--- a/src/Providers/SupplierInvoices/Provider.php
+++ b/src/Providers/SupplierInvoices/Provider.php
@@ -161,9 +161,11 @@ class Provider extends ProviderBase {
    */
   public function create ($givenNumber, array $data)
   {
+    $data['InvoiceNumber'] = $givenNumber;
+
     $req = new FortieRequest();
     $req->method('POST');
-    $req->path($this->basePath)->path($givenNumber);
+    $req->path($this->basePath);
     $req->wrapper('SupplierInvoice');
     $req->data($data);
     $req->setRequired($this->required_create);


### PR DESCRIPTION
Updated Guzzle to work with PHP 7.2. A bug in 6.2.3 prevented it to work properly, and was resolved in 6.3.0 as described here: https://github.com/guzzle/guzzle/issues/1973

Fix issue when creating SupplierInvoice. The InvoiceNumber has to be in the body rather than in the URL.