### PR TITLE
Auto-retry when exceeding rate limit

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -37,6 +37,8 @@ return [
     // The URL to the Fortnox API
     'endpoint'      => 'url-to-fortnox-api',
 
+    // Rate limit (number of requests per second)
+    'rate_limit'  => 4,
   ],
 
 ];


### PR DESCRIPTION
Fortnox decided to set rate limit: https://developer.fortnox.se/documentation/general/regarding-fortnox-api-rate-limits/

In my opinion the easiest fix is to don´t even care about exceeding this limit, just try again in order to accomplish the request.