### PR TITLE
Fix empty response error

### DIFF
--- a/src/Traits/FetchTrait.php
+++ b/src/Traits/FetchTrait.php
@@ -86,10 +86,12 @@ trait FetchTrait
             $totalPages = $response->MetaInformation->{'@TotalPages'};
             $currentPage = $response->MetaInformation->{'@CurrentPage'};
 
-            $items = array_merge(
-                $items,
-                $this->page($currentPage)->all()->{$this->wrapperGroup}
-            );
+            if ($this->page($currentPage)->count() > 0) {
+                $items = array_merge(
+                    $items,
+                    $this->page($currentPage)->all()->{$this->wrapperGroup}
+                );
+            }
         }
 
         // force overwriting meta information header


### PR DESCRIPTION
Avoids 'Undefined property' excepiton when the response contains zero items