### PR TITLE
Attribute Total must be writable for a Supplier invoice

### DIFF
--- a/src/Providers/SupplierInvoices/Provider.php
+++ b/src/Providers/SupplierInvoices/Provider.php
@@ -92,7 +92,7 @@ class Provider extends ProviderBase {
     'SupplierInvoiceRows',
     'SupplierNumber',
     // 'SupplierName',
-    // 'Total',
+    'Total',
     'VAT',
     'VATType',
     'YourReference',


### PR DESCRIPTION
 Attribute Total must be writable for a Supplier invoice otherwise an invoice created via the API will not have the total amount. Such invoice won't be possible to bookkeep in Fortnox since debit and credit will not balance. Fortnox will reject bookkeeping of the invoice. 

![fn](https://github.com/wetcat-studios/fortie/assets/97120700/2934b2df-cce4-47f0-b7e8-b93e5a5baaa7)
